### PR TITLE
Enable formated description for events

### DIFF
--- a/js/timeglider/TG_Mediator.js
+++ b/js/timeglider/TG_Mediator.js
@@ -178,7 +178,8 @@ tg.TG_Mediator.prototype = {
 
 				children.each(function(i){
 					field = keys[i],
-					value = $(this).text();
+					if( field == "description" ) value = $(this).html();
+					else value = $(this).text();
 					// TODO: VALIDATE EVENT STUFF HERE
 
 					row_obj[ field ] = value;


### PR DESCRIPTION
I make a little change on timeglider/TG_Mediator.js to accept html formatted descriptions on events details dialog.
